### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,27 @@
 
 An S3 wrapper that uploads files to your bucket and generates file URL for you.
 
-## Installation
+**Features**:
 
-Installation is done using the
-[`npm install` command](https://docs.npmjs.com/downloading-and-installing-packages-globally) and you should install it globally:
+- Upload files to s3 bucket using aws sdk (v3)
+- Generate random file name or keep the original one
+- TypeScript support
+
+## Installation
 
 ```bash
 $ npm install s3-upload-wrapper
 ```
 
-## Features
-
-- Upload files to s3 bucket using aws sdk (v3)
-- Generate random file name or keep the original one
-
 ## Usage
+
+### Example 1: Basic Usage
+
+`uploadFiles` requires two parameters, `ConfigOptions` to initialize aws sdk and files array from `multer`
 
 ```typescript
 import { uploadFiles } from 's3-upload-wrapper';
 import { ConfigOptions } from 's3-upload-wrapper/lib/types';
-
-uploadFiles requires two parameters, ConfigOptions to initialize aws sdk and files array from multer
-
-Use as below:
 
 let configOptions : ConfigOptions = {
     credentials: {
@@ -38,9 +36,13 @@ let configOptions : ConfigOptions = {
 
 const urls: string[] = await uploadFiles(configOptions, files); // files is Array<Express.Multer.File> from multer
 console.log(urls[0]) // https://yourbucket.s3.region.amazonaws.com/filename
+```
 
-OR if you would like to initialize your own s3 client, you can pass it to the uploadFiles function as part of ConfigOptions instead of credentials
+### Example 2: Providing your own S3 client
 
+If you'd like to initialize your own s3 client, you can pass it to the `uploadFiles` function as part of `ConfigOptions` instead of `credentials`
+
+```typescript
 import { uploadFiles } from 's3-upload-wrapper';
 import { S3Client } from '@aws-sdk/client-s3';
 
@@ -57,6 +59,7 @@ let configOptions = {
     s3Client: s3,
     returnOriginalNames: true // Optional, default is false. if true, then uses original file names received from multer while uploading to bucket
 };
+
 const urls: string[] = await uploadFiles(configOptions, files); // files is Array<Express.Multer.File> from multer
 console.log(urls[0]) // https://yourbucket.s3.region.amazonaws.com/filename
 ```


### PR DESCRIPTION
Tweaking the README.

Re: installing `npm` globally, just no. That's typically only done for modules that provide CLI utilities you expect to use regularly and across multiple projects. E.g. `yarn`, maybe `jest`... that sort of thing.

You might also consider providing the examples as vanilla JS.  It makes them a bit easier to read, and is more approachable for non-TS users.